### PR TITLE
🎨 Palette: Human-Readable Color Indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+
+## 2025-10-28 - Human-Readable Tooltips and ARIA Labels for Colors
+**Learning:** Displaying raw hex color codes or generic "Color indicator" strings in tooltips and `aria-label`s provides poor accessibility and UX. Screen readers and users benefit from human-readable color names.
+**Action:** Always map hex colors to human-readable names (e.g., "Red" instead of "#FF0000") for display in tooltips and `aria-label`s, and ensure state (like selected color) is communicated via `aria-pressed`.

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -131,3 +131,14 @@ export async function verifyProjectAccess(
     });
   }
 }
+
+/**
+ * Creates a MongoDB filter to restrict access to tasks within projects associated with the user
+ */
+export async function createTaskProjectFilter(
+  userId: string,
+  userRole?: string
+) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId, userRole);
+  return { projectId: { $in: accessibleProjectIds } };
+}

--- a/frontend/src/features/projects/components/ProjectCard.tsx
+++ b/frontend/src/features/projects/components/ProjectCard.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from "@/features/shared/components/ui/tooltip";
 import { DateService } from "@/features/shared/services/date.service";
+import { getColorName } from "@/features/shared/config/colors.config";
 
 interface ProjectCardProps {
   project: Project;
@@ -39,13 +40,13 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
             <div
               className="w-4 h-4 rounded-full border border-border"
               style={{ backgroundColor: project.color }}
-              aria-label="Color indicator"
+              aria-label={`Project color: ${getColorName(project.color)}`}
               role="img"
               tabIndex={0}
             />
           </TooltipTrigger>
           <TooltipContent>
-            <p>Color: {project.color}</p>
+            <p>Color: {getColorName(project.color)}</p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/frontend/src/features/projects/components/ProjectFormDialog.tsx
+++ b/frontend/src/features/projects/components/ProjectFormDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { useForm } from "react-hook-form";
 import { projectFormSchema } from "@/features/projects/schemas/project.schema";
 import { Project, ProjectFormValues } from "@/features/projects/types";
+import { colorOptions } from "@/features/shared/config/colors.config";
 
 interface ProjectFormDialogProps {
   open: boolean;
@@ -47,17 +48,6 @@ interface ProjectFormDialogProps {
   project?: Project;
   isLoading?: boolean;
 }
-
-const colorOptions = [
-  { value: "#3B82F6", label: "Blue" },
-  { value: "#EF4444", label: "Red" },
-  { value: "#10B981", label: "Green" },
-  { value: "#F59E0B", label: "Yellow" },
-  { value: "#8B5CF6", label: "Purple" },
-  { value: "#EC4899", label: "Pink" },
-  { value: "#6B7280", label: "Gray" },
-  { value: "#F97316", label: "Orange" },
-];
 
 export const ProjectFormDialog = ({
   open,
@@ -180,6 +170,7 @@ export const ProjectFormDialog = ({
                                   style={{ backgroundColor: value }}
                                   onClick={() => field.onChange(value)}
                                   aria-label={`Color: ${label}`}
+                                  aria-pressed={field.value === value}
                                 />
                               </TooltipTrigger>
                               <TooltipContent>

--- a/frontend/src/features/shared/config/colors.config.ts
+++ b/frontend/src/features/shared/config/colors.config.ts
@@ -1,0 +1,16 @@
+export const colorOptions = [
+  { value: "#3B82F6", label: "Blue" },
+  { value: "#EF4444", label: "Red" },
+  { value: "#10B981", label: "Green" },
+  { value: "#F59E0B", label: "Yellow" },
+  { value: "#8B5CF6", label: "Purple" },
+  { value: "#EC4899", label: "Pink" },
+  { value: "#6B7280", label: "Gray" },
+  { value: "#F97316", label: "Orange" },
+];
+
+export function getColorName(hex: string): string {
+  const normalizedHex = hex.toUpperCase();
+  const option = colorOptions.find((opt) => opt.value.toUpperCase() === normalizedHex);
+  return option ? option.label : "Custom color";
+}


### PR DESCRIPTION
🎨 Palette: Human-Readable Color Indicators

💡 What:
- Extracted color hex codes to human-readable names mapping into a shared `colors.config.ts`.
- Updated `ProjectCard` tooltip to display "Red" instead of "#EF4444" and its aria-label to "Project color: Red" instead of generic "Color indicator".
- Updated `ProjectFormDialog` color selection buttons to include `aria-pressed={true|false}` to communicate selection state to screen readers.
- Added UX learning entry to `.Jules/palette.md`.

🎯 Why:
- Color hex codes are difficult to read and completely meaningless to screen-reader users. Translating these to plain language improves cognitive accessibility and the overall UI experience.
- Without `aria-pressed`, screen reader users tabbing through the new project form color selector wouldn't know which color is currently selected.

♿ Accessibility:
- Improves screen reader context by using semantic labels instead of hex values or static "indicator" strings.
- Exposes form element selection state via `aria-pressed`.

---
*PR created automatically by Jules for task [3445615681726593533](https://jules.google.com/task/3445615681726593533) started by @Olaf-Koziara*