### PR TITLE
🎨 Palette: Improve accessibility of project color picker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,30 +1,3 @@
-## 2024-05-23 - Accessibility of Color-Only Indicators
-**Learning:** Color-coded indicators (like priority badges) without text labels are invisible to screen readers and confusing for color-blind users.
-**Action:** Always wrap such indicators in a tooltip with a text label, and ensure the indicator itself has an `aria-label` or `sr-only` text describing its meaning.
-
-## 2025-09-22 - Accessibility of Icon-Only Dropdown Triggers
-**Learning:** Icon-only dropdown triggers are a common pattern but often lack accessibility context. Adding both `aria-label` and a `Tooltip` provides a complete experience for both screen reader users and visual users.
-**Action:** When using `DropdownMenuTrigger` with an icon button, wrap it in a `Tooltip` > `TooltipTrigger` and ensure the button has a descriptive `aria-label`.
-## 2025-02-18 - Context-Rich Date Tooltips
-**Learning:** Displaying relative status (e.g., "Overdue since", "Due on") in tooltips for date indicators provides critical context that doesn't fit in compact cards.
-**Action:** Use conditional logic inside tooltips to show state-aware messages (overdue/due soon) rather than just the static date.
-
-## 2025-10-27 - Keyboard Accessibility for Non-Interactive Tooltip Triggers
-**Learning:** Tooltips attached to non-interactive elements (like `div` or `span` color indicators) are inaccessible to keyboard users because they cannot receive focus.
-**Action:** Add `tabIndex={0}` and a semantic role (like `role="img"`) to the trigger element to make it focusable and discoverable in the tab order.
-## 2026-02-01 - Keyboard Accessibility for Tooltips on Static Elements
-**Learning:** Wrapping non-interactive elements (like `div` or `Badge`) in `TooltipTrigger` does not make them keyboard-focusable, rendering the tooltip inaccessible to keyboard-only users.
-**Action:** Always add `tabIndex={0}` (and appropriate ARIA roles) to static elements when they trigger tooltips.
-
-## 2025-05-23 - Accessible Interactive Cards
-**Learning:** Clickable cards implemented as `div`s are inaccessible to keyboard users unless explicitly handled.
-**Action:** Add `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers for Enter/Space keys to all interactive card components.
-## 2026-06-25 - Dialog Visibility in Empty Lists
-**Learning:** Conditionally rendering dialogs inside a list's "has items" block prevents them from opening when the list is empty, breaking the "Create New" flow.
-**Action:** Always render dialog components outside of conditional list rendering blocks, typically at the end of the container, to ensure availability regardless of list state.
-## 2025-05-27 - Accessibility of "Clear Filter" Buttons
-**Learning:** Filter components often use icon-only "X" buttons to clear selections. These buttons are frequently missing `aria-label` and `Tooltip`, making them inaccessible and unclear.
-**Action:** Always add `aria-label` describing the specific filter being cleared (e.g., "Clear status filter") and wrap the button in a `Tooltip`.
-## 2026-02-02 - Extending Checkbox Click Targets
-**Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
-**Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+## 2024-03-17 - Added aria-pressed to color picker buttons
+**Learning:** Adding interactive custom buttons like color pickers requires `aria-pressed` for screen readers to properly indicate their state, as visual changes alone are insufficient. Also, providing clear `focus-visible` styling is essential so keyboard navigators know which color they are currently focused on.
+**Action:** Always add `aria-pressed={isActive}` and `focus-visible:ring-2` to custom choice buttons that lack native input semantics, such as the color pickers in `ProjectFormDialog.tsx`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,34 @@
+## 2024-05-23 - Accessibility of Color-Only Indicators
+**Learning:** Color-coded indicators (like priority badges) without text labels are invisible to screen readers and confusing for color-blind users.
+**Action:** Always wrap such indicators in a tooltip with a text label, and ensure the indicator itself has an `aria-label` or `sr-only` text describing its meaning.
+
+## 2025-09-22 - Accessibility of Icon-Only Dropdown Triggers
+**Learning:** Icon-only dropdown triggers are a common pattern but often lack accessibility context. Adding both `aria-label` and a `Tooltip` provides a complete experience for both screen reader users and visual users.
+**Action:** When using `DropdownMenuTrigger` with an icon button, wrap it in a `Tooltip` > `TooltipTrigger` and ensure the button has a descriptive `aria-label`.
+## 2025-02-18 - Context-Rich Date Tooltips
+**Learning:** Displaying relative status (e.g., "Overdue since", "Due on") in tooltips for date indicators provides critical context that doesn't fit in compact cards.
+**Action:** Use conditional logic inside tooltips to show state-aware messages (overdue/due soon) rather than just the static date.
+
+## 2025-10-27 - Keyboard Accessibility for Non-Interactive Tooltip Triggers
+**Learning:** Tooltips attached to non-interactive elements (like `div` or `span` color indicators) are inaccessible to keyboard users because they cannot receive focus.
+**Action:** Add `tabIndex={0}` and a semantic role (like `role="img"`) to the trigger element to make it focusable and discoverable in the tab order.
+## 2026-02-01 - Keyboard Accessibility for Tooltips on Static Elements
+**Learning:** Wrapping non-interactive elements (like `div` or `Badge`) in `TooltipTrigger` does not make them keyboard-focusable, rendering the tooltip inaccessible to keyboard-only users.
+**Action:** Always add `tabIndex={0}` (and appropriate ARIA roles) to static elements when they trigger tooltips.
+
+## 2025-05-23 - Accessible Interactive Cards
+**Learning:** Clickable cards implemented as `div`s are inaccessible to keyboard users unless explicitly handled.
+**Action:** Add `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers for Enter/Space keys to all interactive card components.
+## 2026-06-25 - Dialog Visibility in Empty Lists
+**Learning:** Conditionally rendering dialogs inside a list's "has items" block prevents them from opening when the list is empty, breaking the "Create New" flow.
+**Action:** Always render dialog components outside of conditional list rendering blocks, typically at the end of the container, to ensure availability regardless of list state.
+## 2025-05-27 - Accessibility of "Clear Filter" Buttons
+**Learning:** Filter components often use icon-only "X" buttons to clear selections. These buttons are frequently missing `aria-label` and `Tooltip`, making them inaccessible and unclear.
+**Action:** Always add `aria-label` describing the specific filter being cleared (e.g., "Clear status filter") and wrap the button in a `Tooltip`.
+## 2026-02-02 - Extending Checkbox Click Targets
+**Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
+**Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+
 ## 2024-03-17 - Added aria-pressed to color picker buttons
 **Learning:** Adding interactive custom buttons like color pickers requires `aria-pressed` for screen readers to properly indicate their state, as visual changes alone are insufficient. Also, providing clear `focus-visible` styling is essential so keyboard navigators know which color they are currently focused on.
 **Action:** Always add `aria-pressed={isActive}` and `focus-visible:ring-2` to custom choice buttons that lack native input semantics, such as the color pickers in `ProjectFormDialog.tsx`.

--- a/frontend/src/features/projects/components/ProjectFormDialog.tsx
+++ b/frontend/src/features/projects/components/ProjectFormDialog.tsx
@@ -172,7 +172,7 @@ export const ProjectFormDialog = ({
                               <TooltipTrigger asChild>
                                 <button
                                   type="button"
-                                  className={`w-12 h-12 rounded-lg border-2 transition-all ${
+                                  className={`w-12 h-12 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                                     field.value === value
                                       ? "border-primary scale-110"
                                       : "border-gray-200 hover:border-gray-300"
@@ -180,6 +180,7 @@ export const ProjectFormDialog = ({
                                   style={{ backgroundColor: value }}
                                   onClick={() => field.onChange(value)}
                                   aria-label={`Color: ${label}`}
+                                  aria-pressed={field.value === value}
                                 />
                               </TooltipTrigger>
                               <TooltipContent>


### PR DESCRIPTION
🎨 Palette: Improved accessibility for color selection buttons

💡 **What:** Added `aria-pressed` and `focus-visible` styles to the color picker buttons in `ProjectFormDialog`.
🎯 **Why:** Custom buttons used as a list of choices require `aria-pressed` to inform screen readers of their selection state. Additionally, missing focus visible styles made it impossible to navigate these options using a keyboard.
📸 **Before/After:** Not visually dramatic, but crucial for keyboard and screen reader users. The selected button now correctly announces as pressed.
♿ **Accessibility:**
- Added `aria-pressed={field.value === value}`
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`

---
*PR created automatically by Jules for task [15526199784969440677](https://jules.google.com/task/15526199784969440677) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Color picker buttons now show a visible focus ring for keyboard navigation.
  * Color picker buttons expose selection state to assistive technologies (aria-pressed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->