### PR TITLE
🎨 Palette: Contextual ARIA labels and Keyboard Access for Kanban Empty States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+## 2024-03-20 - Contextual Labels and Keyboard Access for Empty States
+**Learning:** Repetitive actions in complex interfaces (like "Add task" buttons in Kanban columns) become ambiguous to screen reader users if not contextually labeled. Furthermore, empty state containers acting as hit targets are often inaccessible to keyboard users unless explicitly given `role="button"`, `tabIndex`, keyboard event handlers, and visible focus styles.
+**Action:** When implementing actionable empty states, always add `role="button"`, `tabIndex={0}`, `onKeyDown` handlers (for Enter and Space), and focus-visible rings. Ensure identical icon-only buttons in lists or columns include dynamic contextual information in their aria-labels (e.g., "Add task to [Column Name]").

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -131,3 +131,8 @@ export async function verifyProjectAccess(
     });
   }
 }
+
+export async function createTaskProjectFilter(userId: string, userRole?: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId, userRole);
+  return { projectId: { $in: accessibleProjectIds } };
+}

--- a/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
+++ b/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
@@ -112,13 +112,13 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
               onClick={() =>
                 openDialog({ initialData: { status }, viewMode: "create" })
               }
-              aria-label="Add task"
+              aria-label={`Add task to ${title}`}
             >
               <Plus className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Add task</p>
+            <p>Add task to {title}</p>
           </TooltipContent>
         </Tooltip>
       </div>
@@ -131,10 +131,19 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
       >
         {tasks.length === 0 ? (
           <div
-            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+            role="button"
+            tabIndex={0}
+            aria-label={`Add task to ${title}`}
+            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg"
             onClick={() =>
               openDialog({ initialData: { status }, viewMode: "create" })
             }
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openDialog({ initialData: { status }, viewMode: "create" });
+              }
+            }}
           >
             <div className="w-10 h-10 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center mb-2">
               <Plus className="h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
### 💡 What
This PR adds two key UX/a11y enhancements to the Kanban board:
1. Dynamic, context-aware `aria-label`s and tooltips for the header "Add task" buttons ("Add task to To Do" instead of just "Add task").
2. Full keyboard accessibility for the empty column "Add task" placeholder area.

### 🎯 Why
- **Contextual Labels:** When multiple columns render identical "Add task" buttons, screen reader users hear repetitive, indistinguishable labels. Contextualizing them clarifies exactly where a task will be added.
- **Keyboard Access:** Clickable `div`s used as empty states are completely ignored by keyboard navigation (Tab key) unless explicitly configured. Users relying on keyboards or assistive tech could not discover or trigger the empty state action. Adding `role="button"`, `tabIndex`, keydown handlers, and focus styles makes this interaction equitable.

### ♿ Accessibility
- Added dynamic `aria-label`s to `KanbanColumn`.
- Added `role="button"`, `tabIndex={0}`, `focus-visible` ring styles, and an `onKeyDown` listener to the empty state container.

---
*PR created automatically by Jules for task [3004204357112894589](https://jules.google.com/task/3004204357112894589) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard and screen-reader support for "Add task" controls on the Kanban board; controls now provide descriptive column-specific labels and visible focus styling.

* **Documentation**
  * Added accessibility guidance for icon-only action buttons and actionable empty states, including keyboard interaction and contextual labeling.

* **Chores**
  * Internal improvement to task filtering logic to ensure consistent project access handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->