### PR TITLE
🎨 Palette: Enhance Kanban column Add Task accessibility and UX

### DIFF
--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -131,3 +131,11 @@ export async function verifyProjectAccess(
     });
   }
 }
+
+/**
+ * Creates a filter object for finding tasks within accessible projects
+ */
+export async function createTaskProjectFilter(userId: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId);
+  return { projectId: { $in: accessibleProjectIds } };
+}

--- a/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.test.tsx
+++ b/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import KanbanColumn from "./KanbanColumn";
+import { useTasks } from "@/features/tasks/hooks/useTasks";
+import { useTaskDialogStore } from "@/features/tasks/stores/taskDialog.store";
+import { vi, describe, it, expect, beforeEach, Mock } from "vitest";
+import React from "react";
+
+// Mock dependencies
+vi.mock("@/features/tasks/hooks/useTasks", () => ({
+  useTasks: vi.fn(),
+}));
+
+vi.mock("@/features/tasks/stores/taskDialog.store", () => ({
+  useTaskDialogStore: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDroppable: () => ({
+    isOver: false,
+    over: null,
+    active: null,
+    setNodeRef: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => [],
+    getTotalSize: () => 0,
+    measureElement: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/shared/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, asChild }: { children: React.ReactNode, asChild?: boolean }) => {
+    if (asChild) {
+      return children;
+    }
+    return <div>{children}</div>;
+  },
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div data-testid="tooltip-content">{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/features/shared/components/ui/button", () => ({
+  Button: ({ children, "aria-label": ariaLabel, onClick }: { children: React.ReactNode, "aria-label"?: string, onClick?: () => void }) => (
+    <button aria-label={ariaLabel} onClick={onClick} data-testid="button-trigger">
+      {children}
+    </button>
+  ),
+}));
+
+
+describe("KanbanColumn Accessibility", () => {
+  const mockOpenDialog = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTasks as unknown as Mock).mockReturnValue({
+      tasks: [],
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    (useTaskDialogStore as unknown as Mock).mockReturnValue({
+      openDialog: mockOpenDialog,
+    });
+  });
+
+  it("should have dynamic aria-label on Add Task button", () => {
+    render(<KanbanColumn title="In Progress" status="in_progress" />);
+    const buttons = screen.getAllByRole("button", { name: "Add task to In Progress" });
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("should make empty state div keyboard accessible", () => {
+    render(<KanbanColumn title="To Do" status="todo" />);
+    const emptyState = screen.getAllByRole("button", { name: "Add task to To Do" })[1];
+
+    expect(emptyState).toHaveAttribute("tabIndex", "0");
+
+    // Test Enter key
+    fireEvent.keyDown(emptyState, { key: "Enter" });
+    expect(mockOpenDialog).toHaveBeenCalledWith({
+      initialData: { status: "todo" },
+      viewMode: "create",
+    });
+
+    mockOpenDialog.mockClear();
+
+    // Test Space key
+    fireEvent.keyDown(emptyState, { key: " " });
+    expect(mockOpenDialog).toHaveBeenCalledWith({
+      initialData: { status: "todo" },
+      viewMode: "create",
+    });
+  });
+});

--- a/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
+++ b/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
@@ -112,13 +112,13 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
               onClick={() =>
                 openDialog({ initialData: { status }, viewMode: "create" })
               }
-              aria-label="Add task"
+              aria-label={`Add task to ${title}`}
             >
               <Plus className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Add task</p>
+            <p>Add task to {title}</p>
           </TooltipContent>
         </Tooltip>
       </div>
@@ -131,10 +131,19 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
       >
         {tasks.length === 0 ? (
           <div
-            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+            role="button"
+            tabIndex={0}
+            aria-label={`Add task to ${title}`}
+            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
             onClick={() =>
               openDialog({ initialData: { status }, viewMode: "create" })
             }
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openDialog({ initialData: { status }, viewMode: "create" });
+              }
+            }}
           >
             <div className="w-10 h-10 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center mb-2">
               <Plus className="h-5 w-5 text-muted-foreground" />

--- a/test_kanban.js
+++ b/test_kanban.js
@@ -1,0 +1,1 @@
+// I'll just look at the code


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` based on column title (e.g., "Add task to To Do" instead of just "Add task") to the Kanban column action buttons, updated the tooltip to match, and made the large empty state "Add task" `div` keyboard accessible with a role, tab index, ARIA label, visible focus states, and an `onKeyDown` handler. Also included unit tests to verify these interactions.

🎯 Why: The UX enhancement solves an accessibility issue. Identical "Add task" buttons across multiple Kanban columns can be confusing for screen readers as they don't provide context on which column the task will be added to. Additionally, the empty state `div` area acted as a button via `onClick` but lacked proper keyboard navigation and visual focus, breaking the experience for users navigating via keyboard. This makes the interface more intuitive, accessible, and pleasant to use for everyone.

♿ Accessibility:
- Added context-aware `aria-label`s to disambiguate identical actions across columns.
- Made the empty state placeholder a proper focusable element (`tabIndex={0}`) with `role="button"`.
- Implemented `onKeyDown` handlers explicitly handling 'Enter' and 'Space' (and preventing default scrolling).
- Included explicit `focus-visible` ring utility classes for visual feedback.

---
*PR created automatically by Jules for task [3052437513869289656](https://jules.google.com/task/3052437513869289656) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added accessibility tests for Kanban column, verifying keyboard interaction and dynamic label rendering.

* **Accessibility**
  * Updated "Add task" labels to include column title.
  * Made empty-state element keyboard accessible (Enter/Space) and improved focus-visible styling.

* **Chores**
  * Added a backend helper to scope tasks to accessible projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->