### PR TITLE
🎨 Palette: Accessible Kanban Column Add Task Interactions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+
+## 2025-10-31 - Dynamic ARIA Labels in Repeated Contexts
+**Learning:** Generic `aria-label`s (like "Add task") inside repeated components (like Kanban columns) make it impossible for screen reader users to distinguish between the different actions. Also, clickable `div`s used as empty states are inaccessible without explicit roles and keyboard event handlers.
+**Action:** Always interpolate contextual data into ARIA labels (e.g., `aria-label={`Add task to ${title}`}`) in loops/lists, and explicitly transform non-interactive elements into accessible buttons with `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers if they have an `onClick`.

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -98,6 +98,21 @@ export async function getAccessibleProjectOrThrow(
 }
 
 /**
+ * Create a MongoDB filter object that restricts queries to tasks within accessible projects
+ */
+export async function createTaskProjectFilter(
+  userId: string,
+  userRole?: string
+): Promise<{ projectId: { $in: Types.ObjectId[] } } | {}> {
+  if (userRole === "admin") {
+    return {};
+  }
+
+  const accessibleProjectIds = await getAccessibleProjectIds(userId, userRole);
+  return { projectId: { $in: accessibleProjectIds } };
+}
+
+/**
  * Verify user has access to a project and throw appropriate errors if not
  */
 export async function verifyProjectAccess(

--- a/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
+++ b/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
@@ -112,13 +112,13 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
               onClick={() =>
                 openDialog({ initialData: { status }, viewMode: "create" })
               }
-              aria-label="Add task"
+              aria-label={`Add task to ${title}`}
             >
               <Plus className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Add task</p>
+            <p>Add task to {title}</p>
           </TooltipContent>
         </Tooltip>
       </div>
@@ -131,10 +131,19 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
       >
         {tasks.length === 0 ? (
           <div
-            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+            role="button"
+            tabIndex={0}
+            aria-label={`Add task to ${title}`}
+            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
             onClick={() =>
               openDialog({ initialData: { status }, viewMode: "create" })
             }
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openDialog({ initialData: { status }, viewMode: "create" });
+              }
+            }}
           >
             <div className="w-10 h-10 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center mb-2">
               <Plus className="h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
💡 **What:** 
- Updated the "Add task" icon-only button to use a dynamic ARIA label and Tooltip that includes the column title (e.g., "Add task to To Do").
- Transformed the empty state placeholder from a basic clickable `div` into a fully accessible interactive element with keyboard support and focus styling.

🎯 **Why:** 
- Generic ARIA labels ("Add task") inside repeating UI structures (like Kanban columns) make it impossible for screen reader users to know which specific column they are interacting with.
- The empty state was previously inaccessible to keyboard-only users because it lacked `tabIndex`, a semantic role, and keydown event handlers.

📸 **Before/After:**
*(See attached verification screenshot demonstrating focus-visible styling on the empty state)*

♿ **Accessibility:**
- Added dynamic contextual ARIA labels.
- Added `role="button"` and `tabIndex={0}` to the empty state.
- Added `onKeyDown` handler to support Space and Enter keys (calling `e.preventDefault()` to prevent scrolling).
- Added Tailwind `focus-visible` utility classes to show a clear focus ring.

---
*PR created automatically by Jules for task [2253821582476400186](https://jules.google.com/task/2253821582476400186) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-specific "Add task" labels in kanban columns and improved keyboard activation for creating tasks.

* **Accessibility**
  * Reworked interactive placeholders with proper roles, focus styling, and keyboard/ARIA support for better screen-reader and keyboard navigation.

* **Documentation**
  * Added accessibility guidance requiring contextual ARIA labels for repeated/listed actions and rules for making non-semantic clickable elements accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->