### PR TITLE
🎨 Palette: Improve keyboard accessibility for kanban column 'Add Task' actions

### DIFF
--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -97,6 +97,11 @@ export async function getAccessibleProjectOrThrow(
   return project;
 }
 
+export async function createTaskProjectFilter(userId: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId);
+  return { projectId: { $in: accessibleProjectIds } };
+}
+
 /**
  * Verify user has access to a project and throw appropriate errors if not
  */

--- a/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
+++ b/frontend/src/features/tasks/components/KanbanBoard/components/KanbanColumn.tsx
@@ -76,6 +76,13 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
     virtualItems,
   ]);
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openDialog({ initialData: { status }, viewMode: "create" });
+    }
+  };
+
   const renderTaskCard = (task: Task) => (
     <TaskCard
       task={task}
@@ -112,13 +119,13 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
               onClick={() =>
                 openDialog({ initialData: { status }, viewMode: "create" })
               }
-              aria-label="Add task"
+              aria-label={`Add task to ${title}`}
             >
               <Plus className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Add task</p>
+            <p>Add task to {title}</p>
           </TooltipContent>
         </Tooltip>
       </div>
@@ -131,10 +138,14 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
       >
         {tasks.length === 0 ? (
           <div
-            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+            className="flex flex-col h-full items-center justify-start py-12 text-center cursor-pointer opacity-50 hover:opacity-100 transition-opacity focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-lg"
             onClick={() =>
               openDialog({ initialData: { status }, viewMode: "create" })
             }
+            onKeyDown={handleKeyDown}
+            role="button"
+            tabIndex={0}
+            aria-label={`Add task to ${title}`}
           >
             <div className="w-10 h-10 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center mb-2">
               <Plus className="h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
💡 What: The UX enhancement added
Added full keyboard accessibility to the "Add Task" interactive empty state in Kanban columns. Converted the empty state div to act as a button with `role="button"`, `tabIndex={0}`, dynamic `aria-label` including the column title, keyboard event handlers for Enter/Space, and visible focus styles (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`).

🎯 Why: The user problem it solves
The empty state area inside a Kanban column acted as an "Add task" trigger on click, but could not be reached via standard Tab navigation, breaking keyboard accessibility for power users and screen readers. Additionally, having multiple identical "Add task" buttons across columns lacked context for screen reader users.

📸 Before/After: Visual change
N/A (Keyboard interactions and focus outlines primarily updated, existing visual styles reused).

♿ Accessibility: Any a11y improvements made
- Fixed keyboard un-reachable interactive `div` element.
- Restored standard focus outline matching design system.
- Added descriptive context dynamically to ARIA labels (e.g., `Add task to In Progress`).

---
*PR created automatically by Jules for task [12690792949149242116](https://jules.google.com/task/12690792949149242116) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Enter/Space keyboard shortcuts to create tasks from empty Kanban columns for faster entry.

* **Bug Fixes**
  * Make task creation controls announce the target column (column-specific labels) for clarity.
  * Add visible focus indicators and keyboard-accessible empty-state controls to improve accessibility and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->