### PR TITLE
🎨 Palette: Add tooltips to active filter clear buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+## 2026-04-11 - Accessibility of Active Filters Clear Buttons
+**Learning:** In active filter lists, icon-only "X" clear buttons for specific properties lack context for screen readers and can be confusing without visual tooltips.
+**Action:** Always wrap active filter clear buttons in a `Tooltip` and provide a descriptive `aria-label` (e.g., "Clear [Filter Name] filter") to ensure complete accessibility context.

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -131,3 +131,10 @@ export async function verifyProjectAccess(
     });
   }
 }
+
+export async function createTaskProjectFilter(userId: string, userRole?: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId, userRole);
+  return {
+    projectId: { $in: accessibleProjectIds }
+  };
+}

--- a/frontend/src/features/projects/components/ActiveFilters.tsx
+++ b/frontend/src/features/projects/components/ActiveFilters.tsx
@@ -1,5 +1,10 @@
 import { Badge } from "@/features/shared/components/ui/badge";
 import { Button } from "@/features/shared/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/features/shared/components/ui/tooltip";
 import { X } from "lucide-react";
 import React from "react";
 
@@ -40,42 +45,66 @@ export const ActiveFilters: React.FC<ActiveFiltersProps> = ({
       {filters.search && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Search: {filters.search}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("search")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0"
+                onClick={() => onClearFilter("search")}
+                aria-label="Clear Search filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear Search filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.createdBy && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Created By: {getCreatedByName(filters.createdBy)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("createdBy")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0"
+                onClick={() => onClearFilter("createdBy")}
+                aria-label="Clear Created By filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear Created By filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.color && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Color: {getColorLabel(filters.color)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("color")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0"
+                onClick={() => onClearFilter("color")}
+                aria-label="Clear Color filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear Color filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
     </div>


### PR DESCRIPTION
💡 **What**: Added `Tooltip` wrappers and `aria-label` attributes to the "clear" buttons (the "X" icons) inside the active filter badges.
🎯 **Why**: Previously, these icon-only buttons lacked accessible names for screen readers and did not provide visual tooltips on hover. This made it difficult for users relying on assistive technologies to understand the button's purpose and reduced clarity for visual users. Adding descriptive labels (e.g., "Clear Search filter") improves accessibility and general usability.
📸 **Before/After**: See attached video in `frontend_verification_complete`.
♿ **Accessibility**: Added `aria-label="Clear [Filter Name] filter"` to provide clear context for screen readers when focused on the clear button. Wrap inside a `Tooltip` for visual context.

---
*PR created automatically by Jules for task [2419934196205077680](https://jules.google.com/task/2419934196205077680) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated accessibility guidelines for filter controls to ensure clear expectations and compliance with screen reader standards.

* **Accessibility Improvements**
  * Filter clear buttons now include tooltips and descriptive labels, providing better context and discoverability for all users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->