### PR TITLE
🎨 Palette: Added accessible tooltips to ActiveFilters clear buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+## 2024-04-13 - Standardizing Active Filters Accessibility
+**Learning:** Found that while `TaskFilters` used accessible tooltips for clearing filters, the `ActiveFilters` component in projects lacked them. Using Radix UI `<Tooltip>` with `<TooltipTrigger asChild>` wrapper around existing `<Button>` elements is a reliable and consistent pattern to provide descriptive action text ("Remove [x] filter") without disrupting existing visual designs.
+**Action:** Always verify that dynamically generated interactive elements (like active filter tags) mirror the accessibility standards of static forms or toolbars. Specifically, icon-only buttons (`<X />`) inside badges must include `aria-label` and `Tooltip`.

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -97,6 +97,13 @@ export async function getAccessibleProjectOrThrow(
   return project;
 }
 
+export async function createTaskProjectFilter(userId: string, userRole?: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId, userRole);
+  return {
+    projectId: { $in: accessibleProjectIds },
+  };
+}
+
 /**
  * Verify user has access to a project and throw appropriate errors if not
  */

--- a/frontend/src/features/projects/components/ActiveFilters.tsx
+++ b/frontend/src/features/projects/components/ActiveFilters.tsx
@@ -1,5 +1,10 @@
 import { Badge } from "@/features/shared/components/ui/badge";
 import { Button } from "@/features/shared/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/features/shared/components/ui/tooltip";
 import { X } from "lucide-react";
 import React from "react";
 
@@ -40,42 +45,66 @@ export const ActiveFilters: React.FC<ActiveFiltersProps> = ({
       {filters.search && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Search: {filters.search}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("search")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("search")}
+                aria-label="Clear Search filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove Search filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.createdBy && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Created By: {getCreatedByName(filters.createdBy)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("createdBy")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("createdBy")}
+                aria-label="Clear Created By filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove Created By filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.color && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Color: {getColorLabel(filters.color)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("color")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("color")}
+                aria-label="Clear Color filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove Color filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
     </div>


### PR DESCRIPTION
💡 **What**: Added accessible tooltips to the clear filter buttons in the `ActiveFilters` component.
🎯 **Why**: Previously, these icon-only buttons lacked descriptive ARIA labels and tooltips, which made it difficult for screen readers and keyboard users to understand their purpose, in contrast to the `TaskFilters` component which already had them.
♿ **Accessibility**: Added `aria-label`s to the clear buttons and wrapped them in Radix UI Tooltips.

---
*PR created automatically by Jules for task [765704567828302832](https://jules.google.com/task/765704567828302832) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter removal buttons now display helpful tooltips on hover, clearly indicating which filter will be removed.

* **Style**
  * Enhanced visual feedback for filter removal actions with improved destructive hover styling, making removal actions more visually apparent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->