### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to clear filter buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-02-02 - Extending Checkbox Click Targets
 **Learning:** Users often expect the label or row content next to a checkbox to be clickable. Small click targets frustrate users.
 **Action:** Wrap the associated content in a `<label>` element with `htmlFor` matching the checkbox ID to improve hit area and accessibility.
+## 2024-04-25 - Accessibility of "Clear Filter" Buttons
+**Learning:** Filter components often use icon-only "X" buttons to clear selections. These buttons are frequently missing `aria-label` and `Tooltip`, making them inaccessible and unclear.
+**Action:** Always add `aria-label` describing the specific filter being cleared (e.g., "Clear search filter") and wrap the button in a `Tooltip`. Also use `hover:bg-destructive hover:text-destructive-foreground` to visually indicate the destructive action of clearing a filter.

--- a/backend/src/utils/project.utils.ts
+++ b/backend/src/utils/project.utils.ts
@@ -131,3 +131,11 @@ export async function verifyProjectAccess(
     });
   }
 }
+
+/**
+ * Creates a MongoDB filter to match tasks belonging to projects the user has access to.
+ */
+export async function createTaskProjectFilter(userId: string) {
+  const accessibleProjectIds = await getAccessibleProjectIds(userId);
+  return { projectId: { $in: accessibleProjectIds } };
+}

--- a/frontend/src/features/projects/components/ActiveFilters.tsx
+++ b/frontend/src/features/projects/components/ActiveFilters.tsx
@@ -1,5 +1,10 @@
 import { Badge } from "@/features/shared/components/ui/badge";
 import { Button } from "@/features/shared/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/features/shared/components/ui/tooltip";
 import { X } from "lucide-react";
 import React from "react";
 
@@ -40,42 +45,66 @@ export const ActiveFilters: React.FC<ActiveFiltersProps> = ({
       {filters.search && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Search: {filters.search}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("search")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("search")}
+                aria-label="Clear search filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove search filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.createdBy && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Created By: {getCreatedByName(filters.createdBy)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("createdBy")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("createdBy")}
+                aria-label="Clear created by filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove created by filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
 
       {filters.color && (
         <Badge variant="secondary" className="flex items-center gap-1">
           Color: {getColorLabel(filters.color)}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-4 w-4 p-0"
-            onClick={() => onClearFilter("color")}
-          >
-            <X className="h-3 w-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-4 w-4 p-0 hover:bg-destructive hover:text-destructive-foreground"
+                onClick={() => onClearFilter("color")}
+                aria-label="Clear color filter"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove color filter</p>
+            </TooltipContent>
+          </Tooltip>
         </Badge>
       )}
     </div>


### PR DESCRIPTION
🎨 Palette: Accessible 'Clear Filter' Buttons

💡 **What:** Added `aria-label`s and tooltips to the icon-only "Clear filter" (X) buttons within the `ActiveFilters` component in the projects feature. Additionally, updated their hover state to use destructive styling.
🎯 **Why:** Icon-only buttons without text context are inaccessible to screen readers and can be confusing for visual users. Providing clear hover styling (`destructive`) enhances the mental model that clicking the button will perform a destructive action (removing the filter).
📸 **Before/After:** Before, the buttons lacked context. After, they provide clear feedback on hover.
♿ **Accessibility:** Added explicit `aria-label`s (e.g., "Clear search filter") and keyboard-accessible tooltips to clearly announce the button's action.

---
*PR created automatically by Jules for task [8810943678514321029](https://jules.google.com/task/8810943678514321029) started by @Olaf-Koziara*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Filter clear buttons now display helpful tooltips on hover describing the removal action for each filter type.
  * Enhanced accessibility for icon-only filter buttons with improved labeling and destructive-action visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->